### PR TITLE
Update Malawi population value

### DIFF
--- a/js/trialData.js
+++ b/js/trialData.js
@@ -16,7 +16,7 @@ var trialAlt = {
     code: "MWI",
     name: "Malawi",
     properties: {
-      pop: 17907782.55,
+      pop: 17908438.46,
       pop_urban: 2876284.39,
       pop_rural: 15031498.16,
       pop_served: 9480698.478,


### PR DESCRIPTION
@eneedham will regenerate the statistics for the in-country dataset  calculation. But we already know what Malawi will be based on testing in QGIS (The current number is oddly different seemingly because it was generated in ArcMap)

Would be good to merge this before tomorrow at 9am.