### PR TITLE
Add zoom controls to map

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -136,6 +136,13 @@ var mapRegular = new mapboxgl.Map({
   maxBounds: [-180, -59.3, 180, 84.9]
 });
 
+var nav = new mapboxgl.NavigationControl({
+  showCompass: false,
+  showZoom: true
+});
+
+mapRegular.addControl(nav, "top-left");
+
 compare = new mapboxgl.Compare(mapRegular, mapAlt, "#map-container", {
   mousemove: true,
   orientation: "vertical"


### PR DESCRIPTION
By default, Mapbox GL does not add zoom controls. We had a request for the zoom controls to be added.

![image](https://user-images.githubusercontent.com/1809908/69553633-80cd9f80-0f6e-11ea-9014-2788ab5155ee.png)
