### PR TITLE
Change class from sponsor-logo to logo

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1499,7 +1499,7 @@ body:not(.modal-open) .modal-container {
   min-height: calc(100% - (0.5rem * 2));
 }
 
-.sponsor-logo {
+.logo {
   max-width: 170px;
   max-height: 80px;
   margin-right: 15px;

--- a/index.html
+++ b/index.html
@@ -85,19 +85,19 @@
               Sponsors
             </h3>
             <a target="_blank" href="https://azavea.com"
-              ><img class="sponsor-logo" src="/img/logo-azavea.png" alt="Azavea"
+              ><img class="logo" src="/img/logo-azavea.png" alt="Azavea"
             /></a>
             <a
               target="_blank"
               href="http://www.research4cap.org/SitePages/Home.aspx"
               ><img
-                class="sponsor-logo"
+                class="logo"
                 src="/img/logo-recap.png"
                 alt="ReCap: Research for Community Access Partnership"
             /></a>
             <a target="_blank" href="https://www.ukaiddirect.org/"
               ><img
-                class="sponsor-logo"
+                class="logo"
                 src="/img/logo-ukaid.png"
                 alt="UK aid: from the British people"
             /></a>


### PR DESCRIPTION
Minor, non-visible fix. It turns out that the class `sponsor-logo` is blocked by some ad blockers. This will clear up that issue so the logos should appear even if a user has ad blocker.